### PR TITLE
fix misleading error if http Get raises exceptions

### DIFF
--- a/dlipower/dlipower.py
+++ b/dlipower/dlipower.py
@@ -364,8 +364,12 @@ class PowerSwitch(object):
             try:
                 request = requests.get(full_url, auth=(self.userid, self.password,),  timeout=self.timeout)
             except requests.exceptions.RequestException as e:
-                logger.warning("Request timed out - %d retries left.", self.retries - i - 1)
-                logger.debug("Catched exception %s", str(e))
+                if self.retries - i - 1 == 0:
+                    raise DLIPowerException('All {} attempts to Get url "{}" failed.'
+                                            'The last attempt failed with exception:\n{}'
+                                            ''.format(self.retries, full_url, e))  
+                logger.warning('Get url "%s" failed with exception %s - %d retries left.', 
+                               full_url, str(e), self.retries - i - 1)  
                 continue
             if request.status_code == 200:
                 result = request.content


### PR DESCRIPTION
If each requests.get call raises an exception 
you won't get a request object for
logger.debug('Response code: %s', request.status_code)
it will tell you
 'NoneType' object has no attribute 'status_code'

There is 2 ways to fix this. One is to throw an exception
The other is to print a different debug/error message 
if request is None/Falsey.
I chose to print an exception.

Also timeout is not the only possible RequestException
Another possibility is an invalid hostname