### PR TITLE
pool_fix

### DIFF
--- a/dlipower/dlipower.py
+++ b/dlipower/dlipower.py
@@ -557,6 +557,8 @@ class PowerSwitch(object):
                 chunksize=1
             )
         ]
+        pool.close()
+        pool.join()
         if isinstance(result[0], bool):
             for value in result:
                 if value:


### PR DESCRIPTION
Hi,

I ran into memory issues when repeatedly switching outlets, each time the 
command_on_outlets is called a pool is created, this pool however is not dissolved
when the results have been obtained. It remains active to accept new jobs. Each
worker thread will consume memory even if not active, hence every time you're
switching you're consuming a bit more.

This is just the most basic fix, one could however, create a worker pool for every
outlet at the beginning and reuse the pool every time.