### PR TITLE
Handle Switchs with restricted ports

### DIFF
--- a/dlipower/dlipower.py
+++ b/dlipower/dlipower.py
@@ -437,7 +437,7 @@ class PowerSwitch(object):
                     if plug_name and plug_name.strip() == outlet.strip():
                         return plug_number
                 elif isinstance(outlet, int):
-                    if plug_number and plug_number == outlet
+                    if plug_number and plug_number == outlet:
                         return plug_number
         try:
             outlet_int = int(outlet)


### PR DESCRIPTION
When a switch does not let the user have access to all ports, the switch can crash trying to access the port.
If the port the user has access to has a numeric value greater than the total number of ports it has access to, the script throws an exception.

Instead of naively comparing switch port to switchs length, we iterate all ports and compare number.

Example:
Switch grants the user access to Port 5 only.
PowerSwitch.__repr__ displays the port correctly.
PowerSwitch.status(5) or PowerSwitch.status('name') throws exception stating port is out of range.
