### PR TITLE
Fix outlet ranges for names with dashes

### DIFF
--- a/scripts/dlipower
+++ b/scripts/dlipower
@@ -36,32 +36,17 @@ def _block_to_list(block):
         input "1-3,17,19-20"
         output=[1,2,3,17,19,20]
     """
-    block += ','
     result = []
-    val = ''
-    in_range = False
-    for letter in block:
-        if letter in [',', '-']:
-            if in_range:
-                val2 = val
-                val2_len = len(val2)
-                # result += range(int(val1),int(val2)+1)
-                for value in outlet_range(int(val1), int(val2) + 1):
-                    result.append(str(value).zfill(val2_len))
-                val = ''
-                val1 = None
-                in_range = False
-            else:
-                val1 = val
-                val1_len = len(val1)
-                val = ''
-            if letter == ',':
-                if val1 != None:
-                    result.append(val1.zfill(val1_len))
-            else:
-                in_range = True
-        else:
-            val += letter
+    for elem in block.split(','):
+        if '-' in elem:
+            try:
+                val1, val2 = elem.split('-')
+                for value in range(int(val1), int(val2)+1):
+                    result.append(str(value))
+                continue
+            except ValueError:
+                pass
+        result.append(elem)
     return result
 
 


### PR DESCRIPTION
This PR addresses a bug in `_block_to_list` that fails if an outlet name contains a `-`. The following changes will attempt to treat any block element that contains a `-` as a numeric range. If there is an issue converting this to a numeric expression, it is then treated as a string.

This is particularly useful for me since my outlets are named after the hostname for the machine under control. This comes in handy during development when I need to cycle a machine using `dlipower cycle hostname-with-dashes`.