### PR TITLE
Syntax fix for the python_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
 packages =
     dlipower
 
-python_requires = >="3.6"
+python_requires = >=3.6
 zip_safe = True
 
 


### PR DESCRIPTION
New Python does not like quotes around the version definition